### PR TITLE
Add retry example for tower-http-client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
-- Added a `[rate-limiter](tower-http-client/examples/rate_limiter.rs) example.
+- Added a [retry](tower-http-client/examples/retry.rs) example.
+
+- Added a [rate-limiter](tower-http-client/examples/rate_limiter.rs) example.
 
 - **breaking:** Changed `ServiceBuilder::execute` signature to be more
   compatible with the `Service::call` method.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ missing_debug_implementations = "warn"
 unsafe_code = "forbid"
 
 [workspace.lints.clippy]
-pedantic = "warn"
+pedantic = { level = "warn", priority = -1 }
 module_name_repetitions = "allow"
 missing_panics_doc = "warn"
 missing_errors_doc = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ http-body-util = "0.1"
 include-utils = "0.2"
 pin-project = "1.0"
 pretty_assertions = "1.4.0"
-reqwest = { version = "0.12", default-features = false }
+reqwest = { version = "0.12", default-features = false, features = ["stream"] }
 reqwest-middleware = { version = "0.3.0" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -33,6 +33,7 @@ tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
 tower = { version = "0.4" }
 tower-http = { version = "0.5", default-features = false, features = ["util"] }
 wiremock = "0.6.0"
+retry-policies = "0.4.0"
 
 [workspace.lints.rust]
 missing_debug_implementations = "warn"

--- a/flake.lock
+++ b/flake.lock
@@ -18,31 +18,13 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717696253,
-        "narHash": "sha256-1+ua0ggXlYYPLTmMl3YeYYsBXDSCqT+Gw3u6l4gvMhA=",
+        "lastModified": 1720823163,
+        "narHash": "sha256-FZ5dnrvKkln9ESdoTR8R7GKW9rNpXNZrxGsOXsbsTpE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b5328b7f761a7bbdc0e332ac4cf076a3eedb89b",
+        "rev": "f12ee5f64c6a09995e71c9626d88c4efa983b488",
         "type": "github"
       },
       "original": {
@@ -54,11 +36,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1708475490,
-        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
+        "lastModified": 1719690277,
+        "narHash": "sha256-0xSej1g7eP2kaUF+JQp8jdyNmpmCJKRpO12mKl/36Kc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
+        "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
         "type": "github"
       },
       "original": {
@@ -78,17 +60,16 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1717813066,
-        "narHash": "sha256-wqbRwq3i7g5EHIui0bIi84mdqZ/It1AXBSLJ5tafD28=",
+        "lastModified": 1720923816,
+        "narHash": "sha256-GrDL1nFYZrB/+Ah1hNoaNFfduB1agpfqL9QyEl12UOU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6dc3e45fe4aee36efeed24d64fc68b1f989d5465",
+        "rev": "fb8c8be0313f0e6385b3d70151a04ea1d71e4b68",
         "type": "github"
       },
       "original": {
@@ -112,31 +93,16 @@
         "type": "github"
       }
     },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1717850719,
-        "narHash": "sha256-npYqVg+Wk4oxnWrnVG7416fpfrlRhp/lQ6wQ4DHI8YE=",
+        "lastModified": 1720930114,
+        "narHash": "sha256-VZK73b5hG5bSeAn97TTcnPjXUXtV7j/AtS4KN8ggCS0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "4fc1c45a5f50169f9f29f6a98a438fb910b834ed",
+        "rev": "b92afa1501ac73f1d745526adc4f89b527595f14",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722221733,
-        "narHash": "sha256-sga9SrrPb+pQJxG1ttJfMPheZvDOxApFfwXCFO0H9xw=",
+        "lastModified": 1722519197,
+        "narHash": "sha256-VEdJmVU2eLFtLqCjTYJd1J7+Go8idAcZoT11IewFiRg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "12bf09802d77264e441f48e25459c10c93eada2e",
+        "rev": "05405724efa137a0b899cce5ab4dde463b4fd30b",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722305989,
-        "narHash": "sha256-ljiuTGSFuEtudqFqp/5Wr1OuEsVCjur/F2CmlNujSjc=",
+        "lastModified": 1722651535,
+        "narHash": "sha256-2uRmNwxe3CO5h7PfvqXrRe8OplXaEdwhqOUtaF13rpU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "38c2f156fca1868c8be7195ddac150522752f6ab",
+        "rev": "56d83ca6f3c557647476f3720426a7615c22b860",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720823163,
-        "narHash": "sha256-FZ5dnrvKkln9ESdoTR8R7GKW9rNpXNZrxGsOXsbsTpE=",
+        "lastModified": 1722221733,
+        "narHash": "sha256-sga9SrrPb+pQJxG1ttJfMPheZvDOxApFfwXCFO0H9xw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f12ee5f64c6a09995e71c9626d88c4efa983b488",
+        "rev": "12bf09802d77264e441f48e25459c10c93eada2e",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1719690277,
-        "narHash": "sha256-0xSej1g7eP2kaUF+JQp8jdyNmpmCJKRpO12mKl/36Kc=",
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2741b4b489b55df32afac57bc4bfd220e8bf617e",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720923816,
-        "narHash": "sha256-GrDL1nFYZrB/+Ah1hNoaNFfduB1agpfqL9QyEl12UOU=",
+        "lastModified": 1722305989,
+        "narHash": "sha256-ljiuTGSFuEtudqFqp/5Wr1OuEsVCjur/F2CmlNujSjc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fb8c8be0313f0e6385b3d70151a04ea1d71e4b68",
+        "rev": "38c2f156fca1868c8be7195ddac150522752f6ab",
         "type": "github"
       },
       "original": {
@@ -98,11 +98,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1720930114,
-        "narHash": "sha256-VZK73b5hG5bSeAn97TTcnPjXUXtV7j/AtS4KN8ggCS0=",
+        "lastModified": 1722330636,
+        "narHash": "sha256-uru7JzOa33YlSRwf9sfXpJG+UAV+bnBEYMjrzKrQZFw=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "b92afa1501ac73f1d745526adc4f89b527595f14",
+        "rev": "768acdb06968e53aa1ee8de207fd955335c754b7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -58,8 +58,12 @@
           text = ''
             cargo nextest run --workspace --all-targets --no-default-features
             cargo nextest run --workspace --all-targets --all-features
+            
             cargo test --workspace --doc --no-default-features
             cargo test --workspace --doc --all-features
+            
+            cargo run --example rate_limiter
+            cargo run --example retry
           '';
         };
 

--- a/tower-http-client/Cargo.toml
+++ b/tower-http-client/Cargo.toml
@@ -31,9 +31,10 @@ tower-reqwest = { version = "0.3.2", path = "../tower-reqwest" }
 anyhow = { workspace = true }
 futures-util = { workspace = true }
 reqwest = { workspace = true }
+retry-policies = { workspace = true }
 tokio = { workspace = true }
-tower = { workspace = true, features = ["buffer", "limit"] }
-tower-http = { workspace = true, features = ["set-header", "util"] }
+tower = { workspace = true, features = ["buffer", "limit", "retry"] }
+tower-http = { workspace = true, features = ["set-header", "util", "map-request-body"] }
 wiremock = { workspace = true }
 
 [features]

--- a/tower-http-client/examples/rate_limiter.rs
+++ b/tower-http-client/examples/rate_limiter.rs
@@ -60,7 +60,7 @@ async fn main() -> anyhow::Result<()> {
             // Make client compatible with the `tower-http` layers.
             .layer(HttpClientLayer)
             .service(reqwest::Client::new())
-            .map_err(|err| anyhow::anyhow!("{err}"))
+            .map_err(anyhow::Error::msg)
             .boxed_clone(),
     };
 

--- a/tower-http-client/examples/retry.rs
+++ b/tower-http-client/examples/retry.rs
@@ -1,0 +1,148 @@
+use std::{
+    ops::ControlFlow,
+    sync::atomic::{AtomicI32, Ordering::SeqCst},
+    time::SystemTime,
+};
+
+use bytes::Bytes;
+use futures_util::{future::BoxFuture, FutureExt};
+use retry_policies::{policies::ExponentialBackoff, RetryDecision};
+use tower::{ServiceBuilder, ServiceExt as _};
+use tower_http::ServiceBuilderExt as _;
+use tower_http_client::ServiceExt as _;
+use tower_reqwest::{into_reqwest_body, HttpClientLayer};
+use wiremock::{
+    matchers::{method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+#[derive(Debug, Clone)]
+pub struct RetrySequence<P> {
+    policy: P,
+    start_time: Option<SystemTime>,
+    n_past_retries: u32,
+}
+
+impl<P> RetrySequence<P> {
+    pub fn new(policy: P) -> Self {
+        Self {
+            policy,
+            start_time: None,
+            n_past_retries: 0,
+        }
+    }
+
+    pub fn next_attempt(self) -> ControlFlow<(), (SystemTime, Self)>
+    where
+        P: retry_policies::RetryPolicy,
+    {
+        let start_time = self.start_time();
+        match self.policy.should_retry(start_time, self.n_past_retries) {
+            RetryDecision::Retry { execute_after } => ControlFlow::Continue((
+                execute_after,
+                Self {
+                    policy: self.policy,
+                    start_time: Some(start_time),
+                    n_past_retries: self.n_past_retries + 1,
+                },
+            )),
+            RetryDecision::DoNotRetry => ControlFlow::Break(()),
+        }
+    }
+
+    fn start_time(&self) -> SystemTime {
+        self.start_time.unwrap_or_else(SystemTime::now)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SimpleRetry(RetrySequence<ExponentialBackoff>);
+
+impl SimpleRetry {
+    #[must_use]
+    pub fn new(policy: ExponentialBackoff) -> Self {
+        Self(RetrySequence::new(policy))
+    }
+}
+
+impl<ReqBody: Clone, RespBody, E>
+    tower::retry::Policy<http::Request<ReqBody>, http::Response<RespBody>, E> for SimpleRetry
+{
+    type Future = BoxFuture<'static, Self>;
+
+    fn retry(
+        &self,
+        _req: &http::Request<ReqBody>,
+        result: Result<&http::Response<RespBody>, &E>,
+    ) -> Option<Self::Future> {
+        match result {
+            Ok(resp) if !resp.status().is_server_error() => {
+                // Treat almost all `Response`s as success,
+                // so don't retry...
+                None
+            }
+
+            _other => match self.0.clone().next_attempt() {
+                ControlFlow::Continue((retry_at, next_attempt)) => Some(
+                    async move {
+                        eprintln!("Making attempt #{}", next_attempt.n_past_retries);
+                        let sleep_duration = retry_at
+                            .duration_since(SystemTime::now())
+                            .unwrap_or_default();
+                        tokio::time::sleep(sleep_duration).await;
+                        Self(next_attempt)
+                    }
+                    .boxed(),
+                ),
+                // Used all our attempts, no retry...
+                ControlFlow::Break(()) => None,
+            },
+        }
+    }
+
+    fn clone_request(&self, req: &http::Request<ReqBody>) -> Option<http::Request<ReqBody>> {
+        Some(req.clone())
+    }
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    eprintln!("-> Spawning a mock http server...");
+
+    let mock_server = MockServer::start().await;
+    let mock_uri = mock_server.uri();
+
+    let times = AtomicI32::new(3);
+    // Arrange the behaviour of the MockServer adding a Mock:
+    // when it receives a GET request on '/hello' it will respond with a 200.
+    Mock::given(method("GET"))
+        .and(path("/hello"))
+        .respond_with(move |_req: &wiremock::Request| {
+            let old = times.fetch_sub(1, SeqCst);
+            if old < 1 {
+                ResponseTemplate::new(200)
+            } else {
+                ResponseTemplate::new(500)
+            }
+        })
+        .mount(&mock_server)
+        .await;
+
+    eprintln!("-> Creating an HTTP client with Tower layers...");
+    let mut client = ServiceBuilder::new()
+        // Make client compatible with the `tower-http` layers.
+        .retry(SimpleRetry::new(
+            ExponentialBackoff::builder().build_with_max_retries(10),
+        ))
+        // Set the request body type.
+        .map_request_body(|body: http_body_util::Full<Bytes>| into_reqwest_body(body))
+        .layer(HttpClientLayer)
+        .service(reqwest::Client::new())
+        .map_err(anyhow::Error::msg)
+        .boxed_clone();
+
+    let response = client.get(format!("{mock_uri}/hello")).send()?.await?;
+    anyhow::ensure!(response.status().is_success(), "response failed");
+
+    Ok(())
+}

--- a/tower-http-client/src/adapters.rs
+++ b/tower-http-client/src/adapters.rs
@@ -5,5 +5,5 @@
 /// [`reqwest`]: https://crates.io/crates/reqwest
 #[cfg(feature = "reqwest")]
 pub mod reqwest {
-    pub use tower_reqwest::{error, HttpClientLayer, HttpClientService};
+    pub use tower_reqwest::{error, into_reqwest_body, HttpClientLayer, HttpClientService};
 }

--- a/tower-reqwest/Cargo.toml
+++ b/tower-reqwest/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "tower-reqwest"
 description = "Adapter between reqwest and tower-http crates."
-readme = "README.md"
 documentation = "https://docs.rs/crate/tower-reqwest"
+name = "tower-reqwest"
+readme = "README.md"
 version = "0.3.3"
 
+categories.workspace = true
 edition.workspace = true
+keywords.workspace = true
 license.workspace = true
 repository.workspace = true
-categories.workspace = true
-keywords.workspace = true
 rust-version.workspace = true
 
 [features]
@@ -17,8 +17,11 @@ default = []
 reqwest-middleware = ["dep:reqwest-middleware"]
 
 [dependencies]
+bytes = { workspace = true }
 futures-util = { workspace = true }
 http = { workspace = true }
+http-body = { workspace = true }
+http-body-util = { workspace = true }
 include-utils = { workspace = true }
 pin-project = { workspace = true }
 reqwest = { workspace = true }
@@ -29,7 +32,6 @@ tower-http = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-http-body-util = { workspace = true }
 pretty_assertions = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/tower-reqwest/src/adapters/mod.rs
+++ b/tower-reqwest/src/adapters/mod.rs
@@ -1,5 +1,5 @@
 //! Adapters for various clients
 
-mod reqwest;
+pub mod reqwest;
 #[cfg(feature = "reqwest-middleware")]
 mod reqwest_middleware;

--- a/tower-reqwest/src/lib.rs
+++ b/tower-reqwest/src/lib.rs
@@ -4,6 +4,9 @@
 //!
 #![doc = include_utils::include_md!("README.md:description")]
 
+use bytes::Bytes;
+use http_body::Body as HttpBody;
+use http_body_util::BodyDataStream;
 use tower::Layer;
 
 #[doc(inline)]
@@ -41,4 +44,15 @@ impl<S> Layer<S> for HttpClientLayer {
     fn layer(&self, service: S) -> Self::Service {
         HttpClientService(service)
     }
+}
+
+/// Converts an arbitrary body type into the `reqwest::Body` one.
+pub fn into_reqwest_body<B>(body: B) -> reqwest::Body
+where
+    B: HttpBody + Send + Sync + 'static,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    Bytes: From<B::Data>,
+{
+    let stream = BodyDataStream::new(body);
+    reqwest::Body::wrap_stream(stream)
 }


### PR DESCRIPTION
This example is the first step towards creating the complete retry layer for http clients.