### PR TITLE
Expose source error so that `.source()` and `anyhow::Error::root_cause()` can get at the underlying reqwest::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+- Added `#[from]` and `#[source]` to `Error` and `ClientError` to expose the
+  underlying source error.
+
 - Added a `BoxCloneSyncService`, borrowed from this
   [PR](https://github.com/tower-rs/tower/pull/777).
 

--- a/tower-reqwest/src/error.rs
+++ b/tower-reqwest/src/error.rs
@@ -8,7 +8,7 @@ pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 pub enum Error {
     /// An error occurred in the underlying client.
     #[error("Client error: {0}")]
-    Client(ClientError),
+    Client(#[from] ClientError),
     /// An error occurred while processing a middleware.
     #[error("Middleware error: {0}")]
     Middleware(BoxError),
@@ -18,6 +18,7 @@ pub enum Error {
 #[derive(Debug, thiserror::Error)]
 #[error("{inner}")]
 pub struct ClientError {
+    #[source]
     inner: BoxError,
     kind: ClientErrorKind,
 }


### PR DESCRIPTION
With this change, anyhow error `.root_cause()` will return the underlying error, e.g:

```
reqwest::Error: Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" }
```

and tower_request error `.source()` also returns the underlying error instead of None.